### PR TITLE
trouble with running the script on linux

### DIFF
--- a/render_stl.py
+++ b/render_stl.py
@@ -10,13 +10,21 @@ import configparser
 import os
 import subprocess
 import time
+# library to fetch os information
+import platform
+
+# os_is can be 'windows', 'darwin' or 'linux'
+os_is = platform.system().lower()
+# uncommend below for troubleshouting
+# print('the programm is runnuing on ' + os_is)
 
 
 IDLE_PRIORITY_CLASS = 0x00000040
 
 __config = configparser.ConfigParser()
 __config.read("global_settings.ini")
-path_to_openscad = __config.get("environ", "path_to_openscad", fallback="not configured")
+# using f'string' format to create the right os path
+path_to_openscad = __config.get("environ", f"{os_is}_path_to_openscad", fallback="not configured")
 
 
 def render_scad_dir_to_stl_dir(scad_dir, stl_dir):
@@ -35,7 +43,12 @@ def render_scad_dir_to_stl_dir(scad_dir, stl_dir):
             print(outfile, "deleted")
         cmdline = "{} -o \"{}\" \"{}\"".format(path_to_openscad, outfile, filepath)
         print(cmdline)
-        proc = subprocess.Popen(cmdline, creationflags=IDLE_PRIORITY_CLASS)
+        
+        if os_is == 'windows':  # windows path
+            proc = subprocess.Popen(cmdline, creationflags=IDLE_PRIORITY_CLASS)
+        else:                   # mac OS and linux path
+            proc = subprocess.Popen(cmdline, shell=True)
+
         processes.append(proc)
 
     while True:


### PR DESCRIPTION
Hello there,
this is my first contribution to an project, so, it's not perfect, but I hope I can help anyways!

The Issue:
I had problems with running the reference_assembly.py file on my ubuntu system. 
To be more specific, the file render_stl.py did not fetch an appropriate openscad path for different OSes
and the "Popen()" statement did not run appropriate on unix like systems, so I could not run the script.

My solution:
I made a few changes in the render_stl.py and global_settings.ini files for a more os independent and, therefore, a user friendlier behaviour.

1. added a linux specific path in the "global_settings.ini" file, for the openscad program   => line 11 to 20

2. import the "platform" library and initialising, with "system().lower()", a string variable, 
     which contains the name of the os ('windows', 'darwin' or 'linux')                                  => line 14 and 17

3. in the "path_to_openscad" variable I used the f'string' format with the previously
    initialised "os_is" variable, to create the os specific path to openscad                            => line 27

4. using an "if else" statement and the "os_is" variable to distinguish between
    windows and unix like operating systems and using the proper Popen() command       => line 47 to 50

I tested the changes on linux and macOS and it worked.

I hope i could explaine the problem and my solution.
I know, this contribution is not perfekt, because I'm very new to programming, but if I made a mistake,
or I could do something better, please let me know. I'm eager to become a better programmer.

Sincerely Tom