### PR TITLE
trouble with running the script on linux

### DIFF
--- a/global_settings.ini
+++ b/global_settings.ini
@@ -9,12 +9,9 @@ Rods6mm_tightness = .1
 
 [environ]
 # change the os specific path if different
-
 # for windows
 windows_path_to_openscad = C:\Program Files\OpenSCAD\openscad.exe
-
 # for mac OS
 darwin_path_to_openscad = /Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD
-
 # for linux
 linux_path_to_openscad = /bin/openscad

--- a/global_settings.ini
+++ b/global_settings.ini
@@ -8,5 +8,13 @@ Rods6mmBy30mm = True
 Rods6mm_tightness = .1
 
 [environ]
-path_to_openscad = C:\Program Files\OpenSCAD\openscad.exe
-# path_to_openscad = path_to_openscad = /Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD  # for MacOs (?)
+# change the os specific path if different
+
+# for windows
+windows_path_to_openscad = C:\Program Files\OpenSCAD\openscad.exe
+
+# for mac OS
+darwin_path_to_openscad = /Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD
+
+# for linux
+linux_path_to_openscad = /bin/openscad

--- a/render_stl.py
+++ b/render_stl.py
@@ -10,13 +10,20 @@ import configparser
 import os
 import subprocess
 import time
+# library to fetch os information
+import platform
 
+# os_is can be 'windows', 'darwin' or 'linux'
+os_is = platform.system().lower()
+# uncommend below for troubleshouting
+# print('the programm is runnuing on ' + os_is)
 
 IDLE_PRIORITY_CLASS = 0x00000040
 
 __config = configparser.ConfigParser()
 __config.read("global_settings.ini")
-path_to_openscad = __config.get("environ", "path_to_openscad", fallback="not configured")
+# using f'string' format to create the right os path
+path_to_openscad = __config.get("environ", f"{os_is}_path_to_openscad", fallback="not configured")
 
 
 def render_scad_dir_to_stl_dir(scad_dir, stl_dir):
@@ -35,7 +42,10 @@ def render_scad_dir_to_stl_dir(scad_dir, stl_dir):
             print(outfile, "deleted")
         cmdline = "{} -o \"{}\" \"{}\"".format(path_to_openscad, outfile, filepath)
         print(cmdline)
-        proc = subprocess.Popen(cmdline, creationflags=IDLE_PRIORITY_CLASS)
+        if os_is == 'windows':  # windows path
+            proc = subprocess.Popen(cmdline, creationflags=IDLE_PRIORITY_CLASS)
+        else:                   # mac OS and linux path
+            proc = subprocess.Popen(cmdline, shell=True)
         processes.append(proc)
 
     while True:

--- a/render_stl.py
+++ b/render_stl.py
@@ -10,19 +10,15 @@ import configparser
 import os
 import subprocess
 import time
-# library to fetch os information
 import platform
 
 # os_is can be 'windows', 'darwin' or 'linux'
 os_is = platform.system().lower()
-# uncommend below for troubleshouting
-# print('the programm is runnuing on ' + os_is)
 
 IDLE_PRIORITY_CLASS = 0x00000040
 
 __config = configparser.ConfigParser()
 __config.read("global_settings.ini")
-# using f'string' format to create the right os path
 path_to_openscad = __config.get("environ", f"{os_is}_path_to_openscad", fallback="not configured")
 
 


### PR DESCRIPTION
Hello there,
this is my first contribution to an project, so, it's not perfect, but I hope I can help anyways!

The Issue:
I had problems with running the reference_assembly.py file on my ubuntu system.
To be more specific, the file render_stl.py did not fetch an appropriate openscad path for different OSes
and the "Popen()" statement did not run appropriate on unix like systems, so I could not run the script.

My solution:
I made a few changes in the render_stl.py and global_settings.ini files for a more os independent and, therefore, a user friendlier behaviour.
What i did, was adding a Linux path to "global_settings.ini", fetching, with the "platform" library, the actuall os and creating the specific variable for  the openscad folder and finally, using a if else statement to distinguish between windows and unix like systems and using the proper Popen() command.

I tested the changes on linux and macOS and it worked.
I hope i could explaine the problem and my solution.

Thank you to ToBeckmann for the helpful hints 👍
I hope my pull request is now better than my 'first' try.
If I need something to change, please let me know

Sincerely Tom